### PR TITLE
Add automated issue triage workflows

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,126 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  auto-label:
+    name: Auto-label new issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels based on keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const text = `${issue.title ?? ''}\n${issue.body ?? ''}`.toLowerCase();
+
+            const labelRules = [
+              {
+                label: 'resource-suggestion',
+                color: '0e8a16',
+                description: 'Suggestion for a new STEM resource',
+                pattern: /\b(resource|suggestion|add\s+resource|submit)\b/i,
+              },
+              {
+                label: 'broken-link',
+                color: 'd93f0b',
+                description: 'Report of a broken or dead link',
+                pattern: /\b(bug|broken|dead\s*link|404|not\s+working)\b/i,
+              },
+              {
+                label: 'question',
+                color: 'd876e3',
+                description: 'General question about the list',
+                pattern: /\b(question|help|how\s+do\s+i)\b/i,
+              },
+            ];
+
+            const labelsToAdd = [];
+
+            for (const rule of labelRules) {
+              if (rule.pattern.test(text)) {
+                // Ensure the label exists
+                try {
+                  await github.rest.issues.getLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: rule.label,
+                  });
+                } catch (e) {
+                  if (e.status === 404) {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: rule.label,
+                      color: rule.color,
+                      description: rule.description,
+                    });
+                    core.info(`Created label: ${rule.label}`);
+                  } else {
+                    throw e;
+                  }
+                }
+                labelsToAdd.push(rule.label);
+              }
+            }
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: labelsToAdd,
+              });
+              core.info(`Added labels: ${labelsToAdd.join(', ')}`);
+            } else {
+              core.info('No keyword matches — no labels added.');
+            }
+
+  welcome:
+    name: Welcome first-time contributors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if first issue and welcome
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const creator = context.payload.issue.user.login;
+
+            // Check for any previous issues by this user
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              creator: creator,
+              state: 'all',
+              per_page: 2,
+            });
+
+            // If this is their only issue, it's their first time
+            if (issues.length > 1) {
+              core.info(`${creator} has opened issues here before — skipping welcome.`);
+              return;
+            }
+
+            const body = [
+              `👋 Hey @${creator}, welcome and thanks for opening your first issue!`,
+              '',
+              "This is a community-curated list of STEM resources for kids, and contributions like yours help make it better for everyone.",
+              '',
+              "Take a look at the [README](../blob/master/README.md) for an overview of what's already here and how the list is organized.",
+              '',
+              "A maintainer will review this soon. Thanks for helping kids learn! 🚀",
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: body,
+            });
+            core.info(`Welcomed first-time contributor: ${creator}`);

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '30 6 * * *' # Daily at 6:30 UTC
+  workflow_dispatch: # Allow manual runs for testing
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  stale:
+    name: Close stale issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close stale issues
+        uses: actions/stale@v9
+        with:
+          days-before-stale: 90
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it
+            hasn't had any activity in 90 days. It will be closed in 14 days
+            if no further activity occurs. If this is still relevant, leave
+            a comment or remove the `stale` label and it'll stay open.
+          close-issue-message: >
+            This issue has been closed due to inactivity. If you think it
+            should be reopened, feel free to comment and a maintainer can
+            reopen it. Thanks for helping improve STEM resources for kids!
+          exempt-issue-labels: resource-suggestion
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
## What this does

Sets up automated issue triage with two GitHub Actions workflows:

### Issue Triage (`issue-triage.yml`)
Runs when a new issue is opened:

- **Auto-labeling** — scans title and body for keywords and applies labels:
  - `resource-suggestion` — matches "resource", "suggestion", "add resource", "submit"
  - `broken-link` — matches "bug", "broken", "dead link", "404", "not working"
  - `question` — matches "question", "help", "how do i"
  - Labels are created automatically if they don't exist yet
  - Multiple labels can apply if an issue matches more than one pattern

- **First-time welcome** — posts a friendly comment for users opening their first issue, thanking them and pointing to the README

### Stale Issues (`stale.yml`)
Runs daily at 6:30 UTC:

- Marks issues as `stale` after 90 days of inactivity
- Closes stale issues after 14 more days with no response
- **Exempts `resource-suggestion`** issues from auto-closing (backlog items stay open)
- Ignores PRs entirely
- Supports `workflow_dispatch` for manual testing

### Design decisions
- Split into two workflow files to keep event triggers clean (no job-level `if` guards needed)
- Uses `actions/github-script@v7` instead of third-party labeling/welcome actions for flexibility and fewer dependencies
- Word-boundary regex matching to reduce false positives
- Null-safe body handling (issues can be opened with no body)